### PR TITLE
add handling of mitochondrial chromosome

### DIFF
--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -8,6 +8,8 @@ def chr_extract(chr_):
 		return 23
 	elif chr_[-1]=="Y" or chr_[-1]=="y":
 		return 24
+	elif chr_[-1]=="M" or chr_[-1]=="m":
+		return 25
 	else:
 		chrString = ""
 		for i in chr_:


### PR DESCRIPTION
When trying to run scVILP on an mpileup file that also contains entries for `chrM`, the mitochondrial chromosome, it currently throws some weird error (sorry, didn't keep the logs around). This would fix this, simply adding handling for `chrM` and `M`.

However, you might instead want to throw an error and ask users not to input data containing the mitochondrial chromosome, as it is present in a much higher copy number per cell and the inheritance mode of mutations does not adhere to the standard diploid mechanism where both daughter cells will always contain all the mutations of the mother cell (plus maybe some new ones).