### PR TITLE
switch from cdecimal to decimal for python >=3.3

### DIFF
--- a/scripts/scVILP_main.py
+++ b/scripts/scVILP_main.py
@@ -17,7 +17,7 @@ from scipy.special import comb
 from scipy.special import gammaln
 from ete3 import Tree
 import time 
-from cdecimal import Decimal
+from decimal import Decimal
 import scipy.cluster.hierarchy as hier
 import scipy.spatial.distance as dist
 import parser


### PR DESCRIPTION
When setting up scVILP, I ran into dependency solver issues with conda, because I was trying to get scVILP (and gurobi) to work with python `3.6` or `3.7`. Apparently, `cdecimal` doesn't exist any more for those versions, as it has been integrated into python itself as the standard module `decimal`. See e.g. here:
* https://pypi.org/project/cdecimal/
  > Please note: cdecimal has been integrated into CPython 3.3, where it supersedes the pure Python version: import decimal will automatically import the C version. Performance has been improved further, so the cdecimal version shipped with CPython 3.3 is significantly faster for numerical workload than cdecimal-2.3. If you need maximum decimal computing performance, you should solely use that Python version.
* http://www.bytereef.org/mpdecimal/index.html
  > cdecimal has been included in Python-3.3 and later, just “import decimal”.